### PR TITLE
Update ya-errata-import.pl

### DIFF
--- a/ya-errata-import.pl
+++ b/ya-errata-import.pl
@@ -1109,7 +1109,7 @@ foreach my $advid (sort(keys(%{$xml}))) {
   # Generate OVAL ID for redhat security errata
   $ovalid = "";
   if (!$centos_xen_errata && $advid =~ /(CESA|CLSA)-(\d+):(\d+)/) {
-    $ovalid = "oval:com.redhat.rhsa:def:$1".sprintf("%04d", $2);
+    $ovalid = "oval:com.redhat.rhsa:def:$2".sprintf("%04d", $3);
     debug("Processing $advid -- OVAL ID is $ovalid\n");
   }
 


### PR DESCRIPTION
OVAL ID wasn't correct : Red Hat OVAL xml file information will never be matched.
fix: capturing groups of perl regex corrected.
